### PR TITLE
Javadoc build fix

### DIFF
--- a/JGDMS/browser/pom.xml
+++ b/JGDMS/browser/pom.xml
@@ -84,9 +84,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -105,11 +103,13 @@
                           <artifactId>jgdms-lib</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+<!--
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
                           <artifactId>jgdms-dl</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+-->
                     </additionalDependencies>
                 </configuration>
                 

--- a/JGDMS/jgdms-activation/pom.xml
+++ b/JGDMS/jgdms-activation/pom.xml
@@ -67,9 +67,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -82,6 +80,7 @@
                     <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
                     <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
                     <excludePackageNames></excludePackageNames>
+<!--
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -94,6 +93,7 @@
                           <version>${project.version}</version>
                         </additionalDependency>
                     </additionalDependencies>
+-->
                 </configuration>
                 
             </plugin>

--- a/JGDMS/jgdms-collections/pom.xml
+++ b/JGDMS/jgdms-collections/pom.xml
@@ -45,9 +45,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>

--- a/JGDMS/jgdms-discovery-providers/pom.xml
+++ b/JGDMS/jgdms-discovery-providers/pom.xml
@@ -74,9 +74,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -89,6 +87,7 @@
                     <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
                     <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
                     <excludePackageNames></excludePackageNames>
+<!--
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -101,6 +100,7 @@
                           <version>${project.version}</version>
                         </additionalDependency>
                     </additionalDependencies>
+-->
                 </configuration>
                 
             </plugin>

--- a/JGDMS/jgdms-iiop/pom.xml
+++ b/JGDMS/jgdms-iiop/pom.xml
@@ -59,9 +59,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -80,11 +78,13 @@
                           <artifactId>jgdms-lib</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+<!--
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
                           <artifactId>jgdms-dl</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+-->
                     </additionalDependencies>
                 </configuration>
                 

--- a/JGDMS/jgdms-jeri/pom.xml
+++ b/JGDMS/jgdms-jeri/pom.xml
@@ -59,9 +59,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -74,6 +72,7 @@
                     <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
                     <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
                     <excludePackageNames></excludePackageNames>
+<!--
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -86,6 +85,7 @@
                           <version>${project.version}</version>
                         </additionalDependency>
                     </additionalDependencies>
+-->
                 </configuration>
                 
             </plugin>

--- a/JGDMS/jgdms-jrmp/pom.xml
+++ b/JGDMS/jgdms-jrmp/pom.xml
@@ -62,9 +62,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -83,11 +81,13 @@
                           <artifactId>jgdms-lib</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+<!--
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
                           <artifactId>jgdms-dl</artifactId>
                           <version>${project.version}</version>
                         </additionalDependency>
+-->
                     </additionalDependencies>
                 </configuration>
                 

--- a/JGDMS/jgdms-platform/pom.xml
+++ b/JGDMS/jgdms-platform/pom.xml
@@ -83,11 +83,11 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
+                    <!-- @todo Fix javadoc errors, and then restore failOnError to default:true -->
+                    <failOnError>false</failOnError>
                     <links>
                         <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
                         <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>

--- a/JGDMS/jgdms-pref-class-loader/pom.xml
+++ b/JGDMS/jgdms-pref-class-loader/pom.xml
@@ -65,9 +65,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <links>

--- a/JGDMS/jgdms-url-integrity/pom.xml
+++ b/JGDMS/jgdms-url-integrity/pom.xml
@@ -66,9 +66,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <inherited>false</inherited>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
@@ -81,6 +79,7 @@
                     <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
                     <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
                     <excludePackageNames></excludePackageNames>
+<!--
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -93,6 +92,7 @@
                           <version>${project.version}</version>
                         </additionalDependency>
                     </additionalDependencies>
+-->
                 </configuration>
                 
             </plugin>

--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -46,6 +46,10 @@
     <excludeDefaults>true</excludeDefaults>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>2.4</version>
@@ -61,7 +65,6 @@
               <report>project-team</report>
               <report>scm</report>
               <report>index</report>
-              <report>findbugs</report>
             </reports>
             <!--<configuration>
               <aggregate>true</aggregate>
@@ -245,12 +248,24 @@
           <artifactId>gmaven-plugin</artifactId>
           <version>${gmaven.version}</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>findbugs-maven-plugin</artifactId>
+          <version>3.0.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.4</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.3</version>
         <inherited>false</inherited>
         <configuration>
           <locales>en</locales>


### PR DESCRIPTION
Changes to fix 'site' build error related to 'findbugs' report in 'maven-project-info-reports-plugin'.

As a general rule, I try really hard not to require a 'mvn install', and instead to only require 'mvn package' - thereby ensuring only artifacts available to the current maven reactor are needed for a successful build. This approach exposes build dependency issues that can be hidden when 'mvn install' is a requirement to build. The good news is the only problems I saw related to such dependencies occurred during the 'mvn site' goal.

Therefore, I've also commented out some of the javadoc 'additionalDependencies' in some modules where that dependency would not yet be available in the build.

I added a temporary 'workaround' to not failOnError in the 'jgdms-platform' module because there were a number of actual javadoc errors (mostly in the unit test sources) that need to be addressed also.

Apologies if any of these changes are way off base from where you were headed. Please let me know of any adjustments you'd prefer. 

If these changes are merged, should I next try to fix some of the javadoc errors in the 'jgdms-platform' module? I didn't want to conflate this PR with such changes, and was not sure if you wanted such additional divergence from River just for javadoc. I think once that module is fixed, the 'site' goal could be added to the travis build.

Another question: Did you have a URL in mind at which to publish the maven generated site for JGDMS?