### PR TITLE
fix javadoc links to dependencies in other modules.

### DIFF
--- a/JGDMS/browser/pom.xml
+++ b/JGDMS/browser/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-browser</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Service Browser</name>
     <description>Apache JGDMS Example Service Browser
     </description>
@@ -85,18 +84,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -112,7 +100,6 @@
 -->
                     </additionalDependencies>
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/dist/pom.xml
+++ b/JGDMS/dist/pom.xml
@@ -25,7 +25,6 @@
     </parent>
 	<groupId>au.net.zeus.jgdms</groupId>
     <artifactId>dist</artifactId>
-    <url>http://river.apache.org</url>
     <name>JGDMS Distribution</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/extra/pom.xml
+++ b/JGDMS/extra/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>extra</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Extra service utilities</name>
     <description>Apache JGDMS Extra service utilities</description>
     
@@ -59,21 +58,8 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                     <!--<additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -87,7 +73,6 @@
                         </additionalDependency>
                     </additionalDependencies>-->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/groovy-config/pom.xml
+++ b/JGDMS/groovy-config/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>groovy-config</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Groovy Configuration</name>
     <description>Configure JGDMS with Groovy.
     </description>

--- a/JGDMS/jgdms-activation/pom.xml
+++ b/JGDMS/jgdms-activation/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-activation</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Activation Platform</name>
     <description>Apache JGDMS Activation Platform
     </description>
@@ -68,18 +67,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
 <!--
                     <additionalDependencies>
                         <additionalDependency>
@@ -95,7 +83,6 @@
                     </additionalDependencies>
 -->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-collections/pom.xml
+++ b/JGDMS/jgdms-collections/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-collections</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Collection</name>
     <description>Apache JGDMS Collection, Thread and Executor utilities
     </description>
@@ -46,18 +45,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                     <!--<additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -71,7 +59,6 @@
                         </additionalDependency>
                     </additionalDependencies>-->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-destroy/pom.xml
+++ b/JGDMS/jgdms-destroy/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-destroy</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS SharedGroup Destroy</name>
     <description>This executable JAR file is the primary entry point for the Service Starter.
         It acts as both the class path for the container virtual machine (VM) for the Java platform

--- a/JGDMS/jgdms-discovery-providers/pom.xml
+++ b/JGDMS/jgdms-discovery-providers/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-discovery-providers</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Lookup Discovery Providers</name>
     <description>Apache JGDMS Lookup Discovery Providers
     </description>
@@ -75,18 +74,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
 <!--
                     <additionalDependencies>
                         <additionalDependency>
@@ -102,7 +90,6 @@
                     </additionalDependencies>
 -->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-iiop/pom.xml
+++ b/JGDMS/jgdms-iiop/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-iiop</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS IIOP</name>
     <description>JGDMS IIOP Exporter
     </description>
@@ -60,18 +59,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -87,7 +75,6 @@
 -->
                     </additionalDependencies>
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-jeri/pom.xml
+++ b/JGDMS/jgdms-jeri/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-jeri</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Jini Extensible Remote Invocation</name>
     <description>Apache JGDMS Remote Micro Services Platform
     </description>
@@ -60,19 +59,8 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
-<!--
+                  <!--
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -87,7 +75,6 @@
                     </additionalDependencies>
 -->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-jrmp/pom.xml
+++ b/JGDMS/jgdms-jrmp/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-jrmp</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS JRMP</name>
     <description>JGDMS JRMP Exporter
     </description>
@@ -63,18 +62,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                     <additionalDependencies>
                         <additionalDependency>
                           <groupId>au.net.zeus.jgdms</groupId>
@@ -90,7 +78,6 @@
 -->
                     </additionalDependencies>
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-lib-dl/pom.xml
+++ b/JGDMS/jgdms-lib-dl/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-lib-dl</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Service DL Library</name>
 
     <packaging>jar</packaging>

--- a/JGDMS/jgdms-lib/pom.xml
+++ b/JGDMS/jgdms-lib/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-lib</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Service Library</name>
     <description>This artifact contains the JGDMS utility APIs that are not tied
         to a specific service implementation.</description>

--- a/JGDMS/jgdms-osgi-services/pom.xml
+++ b/JGDMS/jgdms-osgi-services/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-osgi-services</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: OSGi JINI service bridge</name>
     <description>JGDMS OSGi JINI Service bridge</description>
     <packaging>jar</packaging>
@@ -70,22 +69,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <inherited>false</inherited>
-                <configuration>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
-                </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-platform/pom.xml
+++ b/JGDMS/jgdms-platform/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-platform</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Jini Platform</name>
     <description>JGDMS Jini Platform, Policy provider, SecurityManager, Constraints and Proxy preparation</description>
    
@@ -84,21 +83,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
                     <!-- @todo Fix javadoc errors, and then restore failOnError to default:true -->
                     <failOnError>false</failOnError>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-pref-class-loader/pom.xml
+++ b/JGDMS/jgdms-pref-class-loader/pom.xml
@@ -28,7 +28,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-pref-class-loader</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Loader</name>
     <description>JGDMS Preferred RMIClassLoader Providers</description>
     <packaging>jar</packaging>
@@ -66,19 +65,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
-                <configuration>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
-                </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-resources/pom.xml
+++ b/JGDMS/jgdms-resources/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-resources</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Resources</name>
     <packaging>jar</packaging>
 

--- a/JGDMS/jgdms-ui-factory/pom.xml
+++ b/JGDMS/jgdms-ui-factory/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-ui-factory</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Service DL Library UI Factory</name>
 
     <packaging>jar</packaging>

--- a/JGDMS/jgdms-url-integrity/pom.xml
+++ b/JGDMS/jgdms-url-integrity/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-url-integrity</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS URL providers and Integrity</name>
     <description>JGDMS URL provider and Integrity verifiers.
     </description>
@@ -67,18 +66,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>false</inherited>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <links>
-                        <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                        <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-                    </links>
-                    <detectLinks>true</detectLinks>
-                    <breakiterator>true</breakiterator>
-                    <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
-                    <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
-                    <excludePackageNames></excludePackageNames>
 <!--
                     <additionalDependencies>
                         <additionalDependency>
@@ -94,7 +82,6 @@
                     </additionalDependencies>
 -->
                 </configuration>
-                
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jini-2.1-compat/pom.xml
+++ b/JGDMS/jini-2.1-compat/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jini-2.1-compat</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Jini 2.1 compatibility</name>
     <description>Compatibilty classes for the com.sun.jini namespace from Jini 2.1
     </description>

--- a/JGDMS/jsk-lib/pom.xml
+++ b/JGDMS/jsk-lib/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jsk-lib</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JSK Library</name>
     <description>
         Defines a classpath for non modular implementations to utilise the Jini

--- a/JGDMS/jsk-platform/pom.xml
+++ b/JGDMS/jsk-platform/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jsk-platform</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JSK Platform</name>
     <description>
         Defines a classpath for non modular implementations to utilise the jini

--- a/JGDMS/phoenix-activation/phoenix-common/pom.xml
+++ b/JGDMS/phoenix-activation/phoenix-common/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.phoenix-activation</groupId>
     <artifactId>phoenix-common</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Phoenix Common</name>    
+    <name>Module :: Phoenix Common</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/phoenix-activation/phoenix-dl/pom.xml
+++ b/JGDMS/phoenix-activation/phoenix-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.phoenix-activation</groupId>
     <artifactId>phoenix-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Phoenix Download</name> 
+    <name>Module :: Phoenix Download</name>
     <packaging>jar</packaging>
 	<dependencies>
         <dependency>

--- a/JGDMS/phoenix-activation/phoenix-group/pom.xml
+++ b/JGDMS/phoenix-activation/phoenix-group/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.phoenix-activation</groupId>
     <artifactId>phoenix-group</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Phoenix Group</name>    
+    <name>Module :: Phoenix Group</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/phoenix-activation/phoenix-init/pom.xml
+++ b/JGDMS/phoenix-activation/phoenix-init/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.phoenix-activation</groupId>
     <artifactId>phoenix-init</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Phoenix Init</name>    
+    <name>Module :: Phoenix Init</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/phoenix-activation/phoenix/pom.xml
+++ b/JGDMS/phoenix-activation/phoenix/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.phoenix-activation</groupId>
     <artifactId>phoenix</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Phoenix</name>    
+    <name>Module :: Phoenix</name>
 
     <packaging>jar</packaging>
     <dependencies>

--- a/JGDMS/phoenix-activation/pom.xml
+++ b/JGDMS/phoenix-activation/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>phoenix-activation</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Phoenix Activation</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -16,7 +16,7 @@
 
   <inceptionYear>2016</inceptionYear>
 
-  <url>https://pfirmstone.github.io/JGDMS/</url>
+  <url>https://${github.repo.basename}.github.io/JGDMS/</url>
 
   <licenses>
     <license>
@@ -68,49 +68,6 @@
           </reportSet>
         </reportSets>
       </plugin>
-      <!--<plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
-        <inherited>false</inherited>
-        <configuration>
-          <aggregate>true</aggregate>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>-->
-        <!--<reportSets>
-          <reportSet>
-            <id>aggregate</id>
-            <configuration>
-              <links>
-                <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
-                <link>https://hudson.apache.org/hudson/view/River/job/River-trunk/javadoc/api/index.html</link>
-              </links>
-              <detectLinks>true</detectLinks>
-              <breakiterator>true</breakiterator>
-              <top></top>
-              <footer></footer>
-              <excludePackageNames></excludePackageNames>
-            </configuration>
-            <reports>
-              <report>aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      
-            <plugin>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <inherited>false</inherited>
-                <configuration>
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-            -->
     </plugins>
   </reporting>
 
@@ -151,9 +108,7 @@
 
     <site>
       <id>${project.artifactId}-site</id>
-      <!-- @todo fix URL to peter's gh repo -->
-      <url>scm:git:git@github.com:bhamail/JGDMS.git</url>
-      <!--<url>scm:git:git@github.com:pfirmstone/JGDMS.git</url>-->
+      <url>scm:git:git@github.com:${github.repo.basename}/JGDMS.git</url>
     </site>
   </distributionManagement>
 
@@ -282,6 +237,19 @@
           <artifactId>maven-scm-publish-plugin</artifactId>
           <version>1.1</version>
         </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.4</version>
+          <configuration>
+            <links>
+              <link>http://java.sun.com/j2se/1.6.0/docs/api/</link>
+            </links>
+            <detectLinks>true</detectLinks>
+            <breakiterator>true</breakiterator>
+            <top><![CDATA[<h2>JGDMS Project ${project.version} API Documentation</h2>]]></top>
+            <footer><![CDATA[<i>Copyright &copy;, multiple authors.</i>]]></footer>
+          </configuration>
+        </plugin>
         <!-- reporting plugins : end -->
       </plugins>
     </pluginManagement>
@@ -343,6 +311,9 @@
   </build>
   
   <properties>
+    <!-- @todo change to peter's gh repo name -->
+    <!--<github.repo.basename>pfirmstone</github.repo.basename>-->
+    <github.repo.basename>bhamail</github.repo.basename>
     <groovy.version>2.2.1</groovy.version>
     <gmaven.version>1.4</gmaven.version>
     <gmavenProviderSelection>2.0</gmavenProviderSelection>

--- a/JGDMS/service-starter/pom.xml
+++ b/JGDMS/service-starter/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>service-starter</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: JGDMS Service Starter</name>
     <description>This executable JAR file is the primary entry point for the Service Starter.
         It acts as both the class path for the container virtual machine (VM) for the Java platform

--- a/JGDMS/services/fiddler/fiddler-dl/pom.xml
+++ b/JGDMS/services/fiddler/fiddler-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.fiddler</groupId>
     <artifactId>fiddler-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Fiddler LookupDiscoveryService Download classes</name> 
+    <name>Module :: Fiddler LookupDiscoveryService Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/fiddler/fiddler-service/pom.xml
+++ b/JGDMS/services/fiddler/fiddler-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.fiddler</groupId>
     <artifactId>fiddler-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Fiddler LookupDiscoveryService Implementation</name>    
+    <name>Module :: Fiddler LookupDiscoveryService Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/fiddler/pom.xml
+++ b/JGDMS/services/fiddler/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>fiddler</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Fiddler the LookupDiscoveryService</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/group/group-dl/pom.xml
+++ b/JGDMS/services/group/group-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.group</groupId>
     <artifactId>group-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Group Service Download classes</name> 
+    <name>Module :: Group Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/group/group-service/pom.xml
+++ b/JGDMS/services/group/group-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.group</groupId>
     <artifactId>group-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Group Service Implementation</name>    
+    <name>Module :: Group Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/group/pom.xml
+++ b/JGDMS/services/group/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>group</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Group</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/mahalo/mahalo-dl/pom.xml
+++ b/JGDMS/services/mahalo/mahalo-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.mahalo</groupId>
     <artifactId>mahalo-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Mahalo Service Download classes</name> 
+    <name>Module :: Mahalo Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/mahalo/mahalo-service/pom.xml
+++ b/JGDMS/services/mahalo/mahalo-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.mahalo</groupId>
     <artifactId>mahalo-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Mahalo Service Implementation</name>    
+    <name>Module :: Mahalo Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/mahalo/pom.xml
+++ b/JGDMS/services/mahalo/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>mahalo</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Mahalo</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/mercury/mercury-dl/pom.xml
+++ b/JGDMS/services/mercury/mercury-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.mercury</groupId>
     <artifactId>mercury-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Mercury Service Download classes</name> 
+    <name>Module :: Mercury Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/mercury/mercury-service/pom.xml
+++ b/JGDMS/services/mercury/mercury-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.mercury</groupId>
     <artifactId>mercury-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Mercury Service Implementation</name>    
+    <name>Module :: Mercury Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/mercury/pom.xml
+++ b/JGDMS/services/mercury/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>mercury</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Mercury the Event Mailbox</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/norm/norm-dl/pom.xml
+++ b/JGDMS/services/norm/norm-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.norm</groupId>
     <artifactId>norm-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Norm Service Download classes</name> 
+    <name>Module :: Norm Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/norm/norm-service/pom.xml
+++ b/JGDMS/services/norm/norm-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.norm</groupId>
     <artifactId>norm-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Norm Service Implementation</name>    
+    <name>Module :: Norm Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/norm/pom.xml
+++ b/JGDMS/services/norm/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>norm</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Norm</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/outrigger/outrigger-dl/pom.xml
+++ b/JGDMS/services/outrigger/outrigger-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.outrigger</groupId>
     <artifactId>outrigger-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Outrigger Service Download classes</name> 
+    <name>Module :: Outrigger Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/outrigger/outrigger-service/pom.xml
+++ b/JGDMS/services/outrigger/outrigger-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.outrigger</groupId>
     <artifactId>outrigger-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Outrigger Service Implementation</name>    
+    <name>Module :: Outrigger Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/outrigger/outrigger-snaplogstore/pom.xml
+++ b/JGDMS/services/outrigger/outrigger-snaplogstore/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.outrigger</groupId>
     <artifactId>outrigger-snaplogstore</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Outrigger Snaplogstore</name> 
+    <name>Module :: Outrigger Snaplogstore</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/outrigger/pom.xml
+++ b/JGDMS/services/outrigger/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>outrigger</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Outrigger</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/reggie/pom.xml
+++ b/JGDMS/services/reggie/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>reggie</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Lookup Service</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/services/reggie/reggie-dl/pom.xml
+++ b/JGDMS/services/reggie/reggie-dl/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.reggie</groupId>
     <artifactId>reggie-dl</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Reggie Service Download classes</name> 
+    <name>Module :: Reggie Service Download classes</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/services/reggie/reggie-service/pom.xml
+++ b/JGDMS/services/reggie/reggie-service/pom.xml
@@ -25,8 +25,7 @@
 
     <groupId>au.net.zeus.jgdms.reggie</groupId>
     <artifactId>reggie-service</artifactId>
-    <url>http://river.apache.org</url>
-    <name>Module :: Reggie Service Implementation</name>    
+    <name>Module :: Reggie Service Implementation</name>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>

--- a/JGDMS/tools/checkconfigurationfile/pom.xml
+++ b/JGDMS/tools/checkconfigurationfile/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>checkconfigurationfile</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Check ConfigurationFile</name>
     <description>Checks the format of the source for a Jini ConfigurationFile. The source
          is specified with either a file, URL, or standard input, as well as with

--- a/JGDMS/tools/checkser/pom.xml
+++ b/JGDMS/tools/checkser/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>checkser</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Check serialversionUid</name>
     <description>Tool to check for serializable classes that do not have explicit
          serialVersionUID fields.

--- a/JGDMS/tools/classdep/pom.xml
+++ b/JGDMS/tools/classdep/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>classdep</artifactId>
-    <url>http://jgdms.apache.org</url>
     <name>Tool :: ClassDep</name>
     <description>Tool used to analyze a set of classes and determine on what other classes
       they directly or indirectly depend. Typically this tool is used to

--- a/JGDMS/tools/classserver/pom.xml
+++ b/JGDMS/tools/classserver/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>classserver</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Class Server</name>
     <description>A simple HTTP server, for serving up JAR and class files. </description>
 

--- a/JGDMS/tools/computedigest/pom.xml
+++ b/JGDMS/tools/computedigest/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>computedigest</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Compute message digest</name>
     <description>Prints the message digest for the contents of a URL. This utility is run
      from the command line.</description>

--- a/JGDMS/tools/computehttpmdcodebase/pom.xml
+++ b/JGDMS/tools/computehttpmdcodebase/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>computehttpmdcodebase</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Compute httpmd codebase</name>
     <description>Computes the message digests for a codebase with HTTPMD URLs. 
         This utility is run from the main command line.

--- a/JGDMS/tools/envcheck/pom.xml
+++ b/JGDMS/tools/envcheck/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>envcheck</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Environment Check</name>
     <description>Tool used to perform validity checks on the run-time environment of a client
           or service. The output of this tool is a report; command-line options

--- a/JGDMS/tools/jarwrapper/pom.xml
+++ b/JGDMS/tools/jarwrapper/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>jarwrapper</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Jar wrapper</name>
     <description> A tool for generating "wrapper" JAR files.  A wrapper JAR file contains a
         Class-Path manifest attribute listing a group of JAR files to

--- a/JGDMS/tools/pom.xml
+++ b/JGDMS/tools/pom.xml
@@ -26,7 +26,6 @@
 
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>tools</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Tools</name>
     <packaging>pom</packaging>
 

--- a/JGDMS/tools/preferredlistgen/pom.xml
+++ b/JGDMS/tools/preferredlistgen/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>preferredlistgen</artifactId>
-    <url>http://river.apache.org</url>
     <name>Tool :: Preferred classes list generator</name>
     <description>Tool used to generate the preferred class information for downloadable JAR
         files in the form of a META-INF/PREFERRED.LIST required for use by the {@link

--- a/JGDMS/tools/security-policy-debug/pom.xml
+++ b/JGDMS/tools/security-policy-debug/pom.xml
@@ -25,7 +25,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms.tools</groupId>
     <artifactId>security-policy-debug</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: DebugDyanamicPolicyProvider and SecurityPolicyWriter</name>
     <description>Tool used to determine security policy requirements.
     </description>

--- a/JGDMS/velocity-config/pom.xml
+++ b/JGDMS/velocity-config/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <groupId>au.net.zeus.jgdms</groupId>
     <artifactId>jgdms-lib</artifactId>
-    <url>http://river.apache.org</url>
     <name>Module :: Velocity configuration provider</name>
     <description>This artifact contains the JGDMS utility APIs that are not tied
         to a specific service implementation.</description>


### PR DESCRIPTION
I figured out why the inter-module dependency links where not working in the javadocs - the module url is used as a base. I removed the module specific urls (so now the modules will inherit from the parent - appending their module name). This seems to fix the javadoc links.

I also defined the common javadoc plugin settings in the root pom.

I've published the updated docs to my forked gh-pages for testing. (https://bhamail.github.io/JGDMS/)

NOTE: need to point to peter's gh-base after merge. see property: <github.repo.basename> in root pom.