### PR TITLE
fix javadoc errors - restore javadoc failOnError to default:true

### DIFF
--- a/JGDMS/jgdms-platform/pom.xml
+++ b/JGDMS/jgdms-platform/pom.xml
@@ -83,10 +83,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- @todo Fix javadoc errors, and then restore failOnError to default:true -->
-                    <failOnError>false</failOnError>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/io/AtomicMarshalInputStreamTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/io/AtomicMarshalInputStreamTest.java
@@ -11,9 +11,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.rmi.UnmarshalException;
-import static org.junit.Assert.*;
+
 import org.junit.Test;
 import tests.support.Have;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -21,9 +23,6 @@ import tests.support.Have;
  */
 public class AtomicMarshalInputStreamTest {
   
-    /**
-     * Test of available method, of class AtomicMarshalInputStream.
-     */
     @Test
     public void testReadObject() throws Exception {
 	System.out.println("available");

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/net/UriTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/net/UriTest.java
@@ -19,7 +19,7 @@ package org.apache.river.api.net;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.util.Locale;
+
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
@@ -82,9 +82,6 @@ public class UriTest extends TestCase {
         return uris;
     }
 
-    /**
-     * @tests java.net.Uri#Uri(java.lang.String)
-     */
     public void test_ConstructorLjava_lang_String() throws URISyntaxException {
         // tests for public Uri(String uri) throws URISyntaxException
 
@@ -251,9 +248,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.Uri#Uri(java.lang.String)
-     */
     public void test_Uri_String() {
         try {
             Uri myUri = new Uri(":abc@mymail.com");
@@ -280,10 +274,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.Uri#Uri(java.lang.String, java.lang.String,
-     *        java.lang.String)
-     */
     public void test_ConstructorLjava_lang_StringLjava_lang_StringLjava_lang_String()
             throws URISyntaxException {
         Uri uri = new Uri("mailto", "mduerst@ifi.unizh.ch", null);
@@ -322,11 +312,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#Uri(java.lang.String, java.lang.String,
-     *        java.lang.String, int, java.lang.String, java.lang.String,
-     *        java.lang.String)
-     */
     public void test_ConstructorLjava_lang_StringLjava_lang_StringLjava_lang_StringILjava_lang_StringLjava_lang_StringLjava_lang_String() {
         // check for URISyntaxException for invalid Server Authority
         construct1("http", "user", "host\u00DFname", -1, "/file", "query",
@@ -412,11 +397,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @throws URISyntaxException
-     * @tests java.net.URI#Uri(java.lang.String, java.lang.String,
-     *        java.lang.String, java.lang.String)
-     */
     public void test_ConstructorLjava_lang_StringLjava_lang_StringLjava_lang_StringLjava_lang_String()
             throws URISyntaxException {
         // relative path
@@ -458,11 +438,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @throws URISyntaxException
-     * @tests java.net.URI#Uri(java.lang.String, java.lang.String,
-     *        java.lang.String, java.lang.String, java.lang.String)
-     */
     public void test_ConstructorLjava_lang_StringLjava_lang_StringLjava_lang_StringLjava_lang_StringLjava_lang_String()
             throws URISyntaxException {
         // URISyntaxException on relative path
@@ -505,11 +480,6 @@ public class UriTest extends TestCase {
                 .toASCIIString());
     }
 
-    /**
-     * @throws URISyntaxException
-     * @tests java.net.URI#Uri(java.lang.String, java.lang.String,
-     *        java.lang.String, java.lang.String, java.lang.String)
-     */
     public void test_fiveArgConstructor() throws URISyntaxException {
         // accept [] as part of valid ipv6 host name
         Uri uri = new Uri("ftp", "[0001:1234::0001]", "/dir1/dir2", "query",
@@ -534,9 +504,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#compareTo(java.lang.Object)
-     */
     public void test_compareToLjava_lang_Object() throws Exception {
         // compareTo tests
 
@@ -609,10 +576,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @throws URISyntaxException
-     * @tests java.net.URI#compareTo(java.lang.Object)
-     */
     public void test_compareTo2() throws URISyntaxException {
         Uri uri, uri2;
 
@@ -635,9 +598,6 @@ public class UriTest extends TestCase {
         assertTrue("TestF", uri2.compareTo(uri) < 0);
     }
 
-    /**
-     * @tests java.net.URI#create(java.lang.String)
-     */
     public void test_createLjava_lang_String() {
         try {
             Uri myUri = Uri.create("a scheme://reg/");
@@ -647,9 +607,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#equals(java.lang.Object)
-     */
     public void test_equalsLjava_lang_Object() throws Exception {
         String[][] equalsData = new String[][] {
                 { "", "" }, // null frags
@@ -720,10 +677,6 @@ public class UriTest extends TestCase {
 
     }
 
-    /**
-     * @throws URISyntaxException
-     * @tests java.net.URI#equals(java.lang.Object)
-     */
     public void test_equals2() throws URISyntaxException {
         // test URIs with empty string authority
         Uri uri = new Uri("http:///~/dictionary");
@@ -744,9 +697,6 @@ public class UriTest extends TestCase {
         assertTrue(uri2.equals(uri));
     }
 
-    /**
-     * @tests java.net.URI#getAuthority()
-     */
     public void test_getAuthority() throws Exception {
         Uri[] uris = getUris();
 
@@ -777,9 +727,6 @@ public class UriTest extends TestCase {
                 .getAuthority());
     }
 
-    /**
-     * @tests java.net.URI#getAuthority()
-     */
     public void test_getAuthority2() throws Exception {
         // tests for URIs with empty string authority component
 
@@ -822,9 +769,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getFragment()
-     */
     public void test_getFragment() throws Exception {
         Uri[] uris = getUris();
 
@@ -846,9 +790,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getHost()
-     */
     public void test_getHost() throws Exception {
         Uri[] uris = getUris();
 
@@ -867,9 +808,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getPath()
-     */
     public void test_getPath() throws Exception {
         Uri[] uris = getUris();
 
@@ -892,9 +830,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getPort()
-     */
     public void test_getPort() throws Exception {
         Uri[] uris = getUris();
 
@@ -909,9 +844,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getPort()
-     */
     public void test_getPort2() throws Exception {
         // if port value is negative, the authority should be
         // consider registry based.
@@ -937,9 +869,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getQuery()
-     */
     public void test_getQuery() throws Exception {
         Uri[] uris = getUris();
 
@@ -961,9 +890,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getRawAuthority()
-     */
     public void test_getRawAuthority() throws Exception {
         Uri[] uris = getUris();
 
@@ -990,9 +916,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getRawFragment()
-     */
     public void test_getRawFragment() throws Exception {
         Uri[] uris = getUris();
 
@@ -1016,9 +939,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getRawPath()
-     */
     public void test_getRawPath() throws Exception {
         Uri[] uris = getUris();
 
@@ -1042,9 +962,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getRawQuery()
-     */
     public void test_getRawQuery() throws Exception {
         Uri[] uris = getUris();
 
@@ -1070,9 +987,6 @@ public class UriTest extends TestCase {
 
     }
 
-    /**
-     * @tests java.net.URI#getRawSchemeSpecificPart()
-     */
     public void test_getRawSchemeSpecificPart() throws Exception {
         Uri[] uris = getUris();
 
@@ -1101,9 +1015,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getRawUserInfo()
-     */
     public void test_getRawUserInfo() throws URISyntaxException {
         Uri[] uris = getUris();
 
@@ -1128,9 +1039,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getScheme()
-     */
     public void test_getScheme() throws Exception {
         Uri[] uris = getUris();
 
@@ -1149,9 +1057,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#getSchemeSpecificPart()
-     */
     public void test_getSchemeSpecificPart() throws Exception {
         Uri[] uris = getUris();
 
@@ -1182,9 +1087,6 @@ public class UriTest extends TestCase {
 
     }
 
-    /**
-     * @tests java.net.URI#getUserInfo()
-     */
     public void test_getUserInfo() throws Exception {
         Uri[] uris = getUris();
 
@@ -1210,9 +1112,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#hashCode()
-     */
     public void test_hashCode() throws Exception {
         String[][] hashCodeData = new String[][] {
                 { "", "" }, // null frags
@@ -1280,9 +1179,6 @@ public class UriTest extends TestCase {
 
     }
 
-    /**
-     * @tests java.net.URI#isAbsolute()
-     */
     public void test_isAbsolute() throws URISyntaxException {
         String[] isAbsoluteData = new String[] { "mailto:user@ca.ibm.com",
                 "urn:isbn:123498989h", "news:software.ibm.com",
@@ -1301,9 +1197,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#isOpaque()
-     */
     public void test_isOpaque() throws URISyntaxException {
         String[] isOpaqueData = new String[] { "mailto:user@ca.ibm.com",
                 "urn:isbn:123498989h", "news:software.ibm.com",
@@ -1322,9 +1215,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#normalize()
-     */
     public void test_normalize() throws Exception {
 
         String[] normalizeData = new String[] {
@@ -1383,9 +1273,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#normalize()
-     */
     public void test_normalize2() throws URISyntaxException {
         Uri uri1 = null, uri2 = null;
         uri1 = new Uri("file:/D:/one/two/../../three");
@@ -1399,9 +1286,6 @@ public class UriTest extends TestCase {
                 "/D:/three", uri2.getRawSchemeSpecificPart());
     }
 
-    /**
-     * @tests java.net.URI#normalize()
-     */
     public void test_normalize3() throws URISyntaxException {
         // return same Uri if it has a normalized path already
         Uri uri1 = null, uri2 = null;
@@ -1422,9 +1306,6 @@ public class UriTest extends TestCase {
         assertEquals(expResult, result);
     }
 
-    /**
-     * @tests java.net.URI#parseServerAuthority()
-     */
     public void test_parseServerAuthority() throws URISyntaxException {
         // registry based uris
         Uri[] uris = null;
@@ -1544,9 +1425,6 @@ public class UriTest extends TestCase {
         assertNotNull(Uri.create("file://C:/1.txt").parseServerAuthority());
     }
 
-    /**
-     * @tests java.net.URI#relativize(java.net.URI)
-     */
     public void test_relativizeLjava_net_Uri() throws URISyntaxException {
         // relativization tests
         String[][] relativizeData = new String[][] {
@@ -1630,9 +1508,6 @@ public class UriTest extends TestCase {
         assertNull(relative.getScheme());
     }
 
-    /**
-     * @tests java.net.URI#relativize(java.net.URI)
-     */
     public void test_relativize2() throws URISyntaxException {
         Uri a = new Uri("http://host/dir");
         Uri b = new Uri("http://host/dir/file?query");
@@ -1669,9 +1544,6 @@ public class UriTest extends TestCase {
         assertEquals(result, one.relativize(two));
     }
 
-    /**
-     * @tests java.net.URI#resolve(java.net.URI)
-     */
     public void test_resolve() throws URISyntaxException {
         Uri uri1 = null, uri2 = null;
         uri1 = new Uri("file:/D:/one/two/three");
@@ -1685,9 +1557,6 @@ public class UriTest extends TestCase {
                 "/D:/one/", uri2.getRawSchemeSpecificPart());
     }
 
-    /**
-     * @tests java.net.URI#resolve(java.net.URI)
-     */
     public void test_resolveLjava_net_Uri() {
         // resolution tests
         String[][] resolveData = new String[][] {
@@ -1741,9 +1610,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#toASCIIString()
-     */
     public void test_toASCIIString() throws Exception {
         Uri[] uris = getUris();
 
@@ -1792,9 +1658,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#toString()
-     */
     public void test_toString() throws Exception {
         Uri[] uris = getUris();
 
@@ -1824,9 +1687,6 @@ public class UriTest extends TestCase {
         }
     }
 
-    /**
-     * @tests java.net.URI#toURL()
-     */
     public void test_toURL() throws Exception {
         String absoluteuris[] = new String[] { "mailto:noreply@apache.org",
                 "urn:isbn:123498989h", "news:software.ibm.com",

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/ConcurrentPolicyFileTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/ConcurrentPolicyFileTest.java
@@ -14,34 +14,30 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
-/**
-* @author Alexey V. Varlamov
-* @version $Revision$
-*/
-
 package org.apache.river.api.security;
 
-import java.net.URI;
-import tests.support.FakePrincipal;
 import java.net.URL;
-import java.security.cert.Certificate;
 import java.security.CodeSource;
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.security.Principal;
 import java.security.ProtectionDomain;
 import java.security.SecurityPermission;
+import java.security.cert.Certificate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
+
 import junit.framework.TestCase;
 import net.jini.security.policy.PolicyInitializationException;
+import tests.support.FakePrincipal;
 
 
 /**
  * Tests for ConcurrentPolicyFile
- * 
+ *
+ * @author Alexey V. Varlamov
+ * @version $Revision$
  */
 public class ConcurrentPolicyFileTest extends TestCase {
 
@@ -67,7 +63,8 @@ public class ConcurrentPolicyFileTest extends TestCase {
     }
 
     /**
-     * Tests that policy is really resetted on refresh(). 
+     * Tests that policy is really resetted on refresh().
+     * @throws PolicyInitializationException if test fails.
      */
     public void testRefresh() throws PolicyInitializationException {
         Permission sp = new SecurityPermission("sdf");
@@ -95,6 +92,7 @@ public class ConcurrentPolicyFileTest extends TestCase {
 
     /**
      * Tests that refresh() does not fail on failing parser.
+     * @throws PolicyInitializationException if test fails.
      */
     public void testRefresh_Failure() throws PolicyInitializationException {
         CodeSource cs = new CodeSource(null, (Certificate[])null);
@@ -105,7 +103,7 @@ public class ConcurrentPolicyFileTest extends TestCase {
 
     /**
      * Tests proper policy evaluation for CodeSource parameters.
-     * @throws java.lang.Exception 
+     * @throws java.lang.Exception if test fails.
      */
     public void testGetPermissions_CodeSource() throws Exception {
         PermissionGrantBuilder pgb = PermissionGrantBuilder.newBuilder();
@@ -146,7 +144,7 @@ public class ConcurrentPolicyFileTest extends TestCase {
 
     /**
      * Tests proper policy evaluation for ProtectionDomain parameters.
-     * @throws java.lang.Exception 
+     * @throws java.lang.Exception if test fails.
      */
     public void testGetPermissions_ProtectionDomain() throws Exception {
         PermissionGrantBuilder pgb = PermissionGrantBuilder.newBuilder();

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/DefaultPolicyParserTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/DefaultPolicyParserTest.java
@@ -23,32 +23,18 @@
 package org.apache.river.api.security;
 
 //import org.apache.river.start.SharedActivationPolicyPermission;
-import java.net.URISyntaxException;
 import java.security.KeyStore;
-import java.util.Properties;
-import java.util.SortedSet;
-import java.io.File;
-import java.io.FileWriter;
-import java.net.URI;
-import java.net.URL;
-import java.security.CodeSource;
 import java.security.Permission;
 import java.security.Principal;
-import java.security.SecurityPermission;
 import java.security.UnresolvedPermission;
-import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.Properties;
 
 import junit.framework.TestCase;
 import org.apache.river.api.security.DefaultPolicyScanner.GrantEntry;
 import org.apache.river.api.security.DefaultPolicyScanner.PermissionEntry;
-import org.apache.river.api.security.PermissionGrant;
-import org.apache.river.api.security.PermissionGrantBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -212,6 +198,7 @@ public class DefaultPolicyParserTest extends TestCase {
 
     /**
      * Test of resolvePermission method, of class DefaultPolicyParser.
+     * @throws Exception if the test fails.
      */
     @Test
     public void testResolvePermission() throws Exception {

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/DelegateSecurityManagerTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/DelegateSecurityManagerTest.java
@@ -54,6 +54,7 @@ public class DelegateSecurityManagerTest {
 
     /**
      * Test of checkPermission method, of class DelegateSecurityManager.
+     * @throws MalformedURLException if the test fails.
      */
     @Test
     public void testCheckPermission() throws MalformedURLException {

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/PermissionCollectionTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/PermissionCollectionTest.java
@@ -17,17 +17,9 @@
 
 package org.apache.river.api.security;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.net.URL;
 import java.security.PermissionCollection;
 import java.security.SecurityPermission;
-import java.util.StringTokenizer;
-
-import tests.support.Support_Exec;
-import tests.support.Support_GetLocal;
-import tests.support.Support_Resources;
 
 /* Test originated from Apace Harmony.  Need to test signed jar file
  * 
@@ -55,7 +47,7 @@ public class PermissionCollectionTest extends junit.framework.TestCase {
     // * the cause of that NPE has still not been determined. Could it be
     // related to Harmony's current stub implementation of BigInteger ?
     /**
-     * @tests java.security.PermissionCollection#implies(java.security.Permission)
+     * tests java.security.PermissionCollection#implies(java.security.Permission)
      */
 //    public void test_impliesLjava_security_Permission() throws Exception{
 //
@@ -202,9 +194,6 @@ public class PermissionCollectionTest extends junit.framework.TestCase {
 //                permCollect.isReadOnly());
 //    }
 
-    /**
-     * @tests java.security.PermissionCollection#setReadOnly()
-     */
     public void test_setReadOnly() {
         // test java.security.permissionCollection.setReadOnly()
         SecurityPermission permi = new SecurityPermission(
@@ -217,9 +206,6 @@ public class PermissionCollectionTest extends junit.framework.TestCase {
                 permCollect.isReadOnly());
     }
 
-    /**
-     * @tests java.security.PermissionCollection#toString()
-     */
     public void test_toString() {
         // test java.security.permissionCollection.toString()
         SecurityPermission permi = new SecurityPermission(

--- a/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/PolicyUtilsTest.java
+++ b/JGDMS/jgdms-platform/src/test/java/org/apache/river/api/security/PolicyUtilsTest.java
@@ -24,22 +24,14 @@ package org.apache.river.api.security;
 
 import java.io.File;
 import java.net.URL;
-import java.security.AllPermission;
 import java.security.Permission;
-import java.security.PermissionCollection;
 import java.security.Security;
 import java.security.SecurityPermission;
 import java.security.UnresolvedPermission;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.Properties;
 
 import junit.framework.TestCase;
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 
@@ -72,7 +64,10 @@ public class PolicyUtilsTest extends TestCase {
 //        system = null;
 //    }
 
-    /** Tests valid expansion of ${key} entries. */
+    /**
+     * Tests valid expansion of ${key} entries.
+     * @throws Exception if the test fails.
+     */
     public void testExpand() throws Exception {
         String[] input = new String[] { "${key.1}", "abcd${key.1}",
                 "a ${key.1} b ${$key$}${key.2}", "$key.1", "${}" };
@@ -88,7 +83,10 @@ public class PolicyUtilsTest extends TestCase {
         }
     }
 
-    /** Tests ExpansionFailedException for missing keys of ${key} entries. */
+    /**
+     * Tests ExpansionFailedException for missing keys of ${key} entries.
+     * @throws Exception if the test fails.
+     */
     public void testExpandFailed() throws Exception {
         try {
             PolicyUtils.expand("${key.123}", new Properties());
@@ -97,7 +95,10 @@ public class PolicyUtilsTest extends TestCase {
         catch (PolicyUtils.ExpansionFailedException ok) {}
     }
 
-    /** Tests valid URL-specific expansion. */
+    /**
+     * Tests valid URL-specific expansion.
+     * @throws Exception if the test fails.
+     */
     public void testExpandURL() throws Exception {
         String input = "file:/${my.home}" + File.separator + "lib/extensions/";
         Properties props = new Properties();
@@ -107,7 +108,10 @@ public class PolicyUtilsTest extends TestCase {
                 props));
     }
 
-    /** Tests valid expansion of ${{protocol:data}} entries. */
+    /**
+     * Tests valid expansion of ${{protocol:data}} entries.
+     * @throws Exception if the test fails.
+     */
     public void testExpandGeneral() throws Exception {
         String[] input = new String[] { "${{a:b}}", "a ${{self}}${{a: made}}",
                 "${{}}" };
@@ -136,6 +140,7 @@ public class PolicyUtilsTest extends TestCase {
     /** 
      * Tests ExpansionFailedException for undefined protocol 
      * of ${{protocol:data}} entries. 
+     * @throws Exception if the test fails.
      */
     public void testExpandGeneralFailed() throws Exception {
         try {
@@ -176,8 +181,9 @@ public class PolicyUtilsTest extends TestCase {
 
     /**
      * Tests cases of enabled/disabled system URL.
+     * @throws Exception if the test fails.
      */
-    public void testGetPolicyURLs01() throws Throwable {
+    public void testGetPolicyURLs01() throws Exception {
         final String KEY_DYNAMIC = "policy.allowSystemProperty";
         String OLD_DYNAMIC = Security.getProperty(KEY_DYNAMIC);
 
@@ -207,8 +213,11 @@ public class PolicyUtilsTest extends TestCase {
         }
     }
 
-    /** Tests finding algorithm for numbered locations in security properties. */
-    public void testGetPolicyURLs02() throws Throwable {
+    /**
+     * Tests finding algorithm for numbered locations in security properties.
+     * @throws Exception if the test fails.
+     */
+    public void testGetPolicyURLs02() throws Exception {
         final String PREFIX = "testGetPolicyURLs02.";
         String[] OLD = new String[5];
         for (int i = 0; i < OLD.length; i++) {
@@ -249,8 +258,9 @@ public class PolicyUtilsTest extends TestCase {
 
     /**
      * Tests expansion in system and security URLs.
+     * @throws Exception if the test fails.
      */
-    public void testGetPolicyURLs03() throws Throwable {
+    public void testGetPolicyURLs03() throws Exception {
         final String KEY_DYNAMIC = "policy.allowSystemProperty";
         final String OLD_DYNAMIC = Security.getProperty(KEY_DYNAMIC);
         final String KEY_EXP = "policy.expandProperties";
@@ -301,7 +311,7 @@ public class PolicyUtilsTest extends TestCase {
         }
     }
     
-    public void testInstantiatePermission() throws Throwable {
+    public void testInstantiatePermission() throws Exception {
         String name = "abc";
         Permission expected = new SecurityPermission(name);
         //test valid input


### PR DESCRIPTION
Removed unrecognized "@tests" annotations in comments. Removed incomplete comments where no added info was provided by the existing comment. Completed incomplete comments. Some other minor cleanups.

The "import" cleanups were from my IDE automagically, and they appear better to me. Will remove them if preferred.