### PR TITLE
flip the switch: change to peter's gh-pages repo name

### DIFF
--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -224,10 +224,6 @@
           <version>3.0.4</version>
         </plugin>
         <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>2.4</version>
         </plugin>

--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -99,6 +99,13 @@
     <!-- FILL IN THE REST OF YOUR DEVELOPERS -->
   </developers>
 
+  <contributors>
+    <contributor>
+      <name>Dan Rollo</name>
+      <timezone>-4</timezone>
+    </contributor>
+  </contributors>
+
   <distributionManagement>
     <!--<snapshotRepository>
       <id>local-snapshots</id>

--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -12,7 +12,7 @@
 
   <name>JGDMS Project</name>
 
-  <description>JGDMS Project</description>
+  <description>Infrastructure for providing secured micro services, that are dynamically discoverable and searchable over ipv6 networks.</description>
 
   <inceptionYear>2016</inceptionYear>
 

--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -311,9 +311,7 @@
   </build>
   
   <properties>
-    <!-- @todo change to peter's gh repo name -->
-    <!--<github.repo.basename>pfirmstone</github.repo.basename>-->
-    <github.repo.basename>bhamail</github.repo.basename>
+    <github.repo.basename>pfirmstone</github.repo.basename>
     <groovy.version>2.2.1</groovy.version>
     <gmaven.version>1.4</gmaven.version>
     <gmavenProviderSelection>2.0</gmavenProviderSelection>

--- a/JGDMS/src/site/markdown/docdocs.md
+++ b/JGDMS/src/site/markdown/docdocs.md
@@ -36,5 +36,10 @@ we need to run a number of commands in order to successfully publish the site:
 
      Shorter commands (like `mvn clean site-deploy`) run into a number of problems. If you find
      a shorter incantation that works reliably, please share your findings!
+     
+     NOTE: The first time publishing a large site tree, I saw some errors related to command size limits.
+     The workaround for the first time publishing was to manually push large tree changes to the gh-pages branch. 
+     Thereafter the command size limit issue was avoided because fewer new changes were being published to 
+     gh-pages via the above publish command.
 
 For more details see: [Maven Multi Module Configuration](https://maven.apache.org/plugins/maven-scm-publish-plugin/examples/multi-module-configuration.html)


### PR DESCRIPTION
This PR has some minor doc tweaks, however the biggest change is the smallest one: changing the value of 'github.repo.basename' to pfirmstone. With this change, the documented publish commands will write to the "real" gh-pages branch in Peter's repository.

If you're ready to "flip the switch", please try publishing and holler if bad things happen. (It may well choke the first time due to command size limits).

