### PR TITLE
findbugs fix: class extends and adds fields, but does not implement e…

### DIFF
--- a/JGDMS/jgdms-platform/src/main/java/net/jini/core/transaction/server/NestableServerTransaction.java
+++ b/JGDMS/jgdms-platform/src/main/java/net/jini/core/transaction/server/NestableServerTransaction.java
@@ -17,12 +17,15 @@
  */
 package net.jini.core.transaction.server;
 
-import java.io.IOException;
-import java.rmi.RemoteException;
 import net.jini.core.lease.LeaseDeniedException;
-import net.jini.core.transaction.*;
+import net.jini.core.transaction.CannotJoinException;
+import net.jini.core.transaction.NestableTransaction;
+import net.jini.core.transaction.UnknownTransactionException;
 import org.apache.river.api.io.AtomicSerial;
 import org.apache.river.api.io.AtomicSerial.GetArg;
+
+import java.io.IOException;
+import java.rmi.RemoteException;
 
 /**
  * Class implementing the <code>NestableTransaction</code> interface, for use
@@ -171,5 +174,23 @@ public class NestableServerTransaction extends ServerTransaction
 	    ", id=" + id +
             ", parent=" + parent +
 	    "]";
-    }    
+    }
+
+    /**
+     * {@inheritDoc}
+     * The assumption here is two transactions are still equal if they have the same transaction manager
+     * and the same transaction id, regardless of whether one is or is not nested.
+     */
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     * The assumption here is two transactions are still equal if they have the same transaction manager
+     * and the same transaction id, regardless of whether one is or is not nested.
+     */
+    public boolean equals(final Object other) {
+        return super.equals(other);
+    }
 }


### PR DESCRIPTION
…quals() or hashCode() - explicitly ignores "nested" state during comparisons.

This PR makes a minor FindBugs fix.

While working on another FindBugs fix: 
org.apache.river.api.security.Segment defines compareTo(Object) and uses Object.equals() | BAD_PRACTICE | EQ_COMPARETO_USE_OBJECT_EQUALS | 130-136

I got confused. I was trying to run some unit tests of org.apache.river.api.security.Segment, but my IDE compiler was complaining about a number of jdk 1.8 classes. When I looked at the pom.xml's for jgdm-collections and jgdm-platform modules, they appear to specify only jdk 1.5 in the maven-compiler-plugin config. Since the maven CLI build succeeds, I guess I'm missing something. What jdk should these modules require?

After I get that cleared up, I will start trying to understand if it's OK that Segment doesn't override .equals().
 

