### PR TITLE
Findbugs fix, and serialization questions

### DIFF
--- a/JGDMS/jgdms-collections/src/main/java/org/apache/river/concurrent/ReferenceCollection.java
+++ b/JGDMS/jgdms-collections/src/main/java/org/apache/river/concurrent/ReferenceCollection.java
@@ -52,7 +52,7 @@ class ReferenceCollection<T> extends AbstractCollection<T>
                                 implements Collection<T>, Serializable {
     private static final long serialVersionUID = 1L;
     private final Collection<Referrer<T>> col;
-    private final ReferenceQueuingFactory<T, Referrer<T>> rqf;
+    private final transient ReferenceQueuingFactory<T, Referrer<T>> rqf;
     private final Ref type;
     
     @SuppressWarnings("unchecked")

--- a/JGDMS/jgdms-collections/src/test/java/org/apache/river/concurrent/ReferenceCollectionTest.java
+++ b/JGDMS/jgdms-collections/src/test/java/org/apache/river/concurrent/ReferenceCollectionTest.java
@@ -15,15 +15,11 @@
 
 package org.apache.river.concurrent;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+
+import java.io.*;
+import java.util.*;
+
 import static org.junit.Assert.*;
 
 /**
@@ -243,5 +239,32 @@ public class ReferenceCollectionTest {
         System.out.println("clear");
         instance.clear();
         assertTrue( instance.isEmpty() );
+    }
+
+    /**
+     * Test of serializing instance of ReferenceCollection.
+     */
+    @Test
+    public void testSerialize() throws IOException, ClassNotFoundException {
+        System.out.println("Serialize");
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        new ObjectOutputStream(byteArrayOutputStream).writeObject(instance);
+        final ReferenceCollection<String> serialInstance = (ReferenceCollection<String>) new ObjectInputStream(
+                new ByteArrayInputStream(byteArrayOutputStream.toByteArray())).readObject();
+        // @todo There appears to be a problem with org.apache.river.concurrent.ReferenceCollection.equals(), because
+        // col.equals(o) returns false due to o not being an instance of List
+        //assertTrue(instance.equals(serialInstance));
+
+        // temporary workaround is to compare contents of lists
+        // but I must misunderstand how instance.containsAll(serialInstance) is intended to work, as this too fails.
+        //assertTrue(instance.containsAll(serialInstance));
+
+        // plain old iterator appears to work
+        final Iterator<String> origIter = instance.iterator();
+        final Iterator<String> serialIter = serialInstance.iterator();
+        while (origIter.hasNext() && serialIter.hasNext()) {
+            assertTrue(origIter.next().equals(serialIter.next()));
+        }
+        assertTrue(!origIter.hasNext() && !serialIter.hasNext());
     }
 }

--- a/JGDMS/jgdms-collections/src/test/java/org/apache/river/concurrent/ReferrerTimeTest.java
+++ b/JGDMS/jgdms-collections/src/test/java/org/apache/river/concurrent/ReferrerTimeTest.java
@@ -146,7 +146,7 @@ public class ReferrerTimeTest {
                 Ref.TIME, 20L);
         Future f = new F();
         que.offer(f);
-        Thread.sleep(80L);
+        Thread.sleep(100L);
         assertTrue(f.isCancelled());
     }
     


### PR DESCRIPTION
See code comments in second commit. I'm probably misunderstanding something, but it appears .equals() breaks after serialization of a ReferenceCollection.