### PR TITLE
compiler <release> tag requires maven 3.6+

### DIFF
--- a/JGDMS/groovy-config/pom.xml
+++ b/JGDMS/groovy-config/pom.xml
@@ -124,7 +124,6 @@
                 <configuration>
                         <source>6</source>
                         <target>6</target>
-                        <release>6</release>
                         <optimize>true</optimize>
                         <encoding>UTF-8</encoding>
                         <meminitial>128m</meminitial>


### PR DESCRIPTION
I was debugging a CI build failure, and I think the cause is the use of a new compiler tag that is only valid in maven version >= v3.6. Do we want/need that requirement now?

Assuming not, I removed the tag so older maven versions will still work.

(My CI build using an older maven version succeeded, so I'm pretty sure this PR fixes the issue).
Please ignore the unrelated commit comment below - side effect of merging upstream.