### PR TITLE
fix compile error from: replacement of Class::newInstance() is deprec…

### DIFF
--- a/JGDMS/services/outrigger/outrigger-dl/src/main/java/org/apache/river/outrigger/proxy/EntryRep.java
+++ b/JGDMS/services/outrigger/outrigger-dl/src/main/java/org/apache/river/outrigger/proxy/EntryRep.java
@@ -17,16 +17,25 @@
  */
 package org.apache.river.outrigger.proxy;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InvalidObjectException;
-import java.io.ObjectInput;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import net.jini.core.entry.Entry;
+import net.jini.core.entry.UnusableEntryException;
+import net.jini.id.Uuid;
+import net.jini.id.UuidFactory;
+import net.jini.io.MarshalledInstance;
+import net.jini.space.JavaSpace;
+import org.apache.river.api.io.AtomicSerial;
+import org.apache.river.api.io.AtomicSerial.GetArg;
+import org.apache.river.api.io.AtomicSerial.ReadInput;
+import org.apache.river.api.io.AtomicSerial.ReadObject;
+import org.apache.river.landlord.LeasedResource;
+import org.apache.river.logging.Levels;
+import org.apache.river.proxy.CodebaseProvider;
+import org.apache.river.proxy.MarshalledWrapper;
+
+import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.rmi.MarshalException;
@@ -38,21 +47,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
-import net.jini.core.entry.Entry;
-import net.jini.core.entry.UnusableEntryException;
-import net.jini.id.Uuid;
-import net.jini.id.UuidFactory;
-import net.jini.io.MarshalledInstance;
-import net.jini.space.JavaSpace;
-import org.apache.river.api.io.AtomicMarshalInputStream;
-import org.apache.river.api.io.AtomicSerial;
-import org.apache.river.api.io.AtomicSerial.GetArg;
-import org.apache.river.api.io.AtomicSerial.ReadInput;
-import org.apache.river.api.io.AtomicSerial.ReadObject;
-import org.apache.river.landlord.LeasedResource;
-import org.apache.river.logging.Levels;
-import org.apache.river.proxy.CodebaseProvider;
-import org.apache.river.proxy.MarshalledWrapper;
 
 /**
  * An <code>EntryRep</code> object contains a packaged
@@ -475,7 +469,7 @@ public class EntryRep implements StorableResource<EntryRep>, LeasedResource, Ser
 	try {
 	    ArrayList badFields = null;
 	    ArrayList except = null;
-            Entry entryObj = null;
+            final Entry entryObj;
             int valuesLength = 0;
             int nvals = 0;		// index into this.values[]
                       
@@ -489,7 +483,15 @@ public class EntryRep implements StorableResource<EntryRep>, LeasedResource, Ser
                     throw throwNewUnusableEntryException(
                         new IncompatibleClassChangeError(realClass + " changed"));
 
-                entryObj = (Entry) realClass.getDeclaredConstructor().newInstance();
+		try {
+		    entryObj = (Entry) realClass.getDeclaredConstructor().newInstance();
+		} catch (NoSuchMethodException e) {
+		    throw throwNewUnusableEntryException(
+			    new IncompatibleClassChangeError(realClass + " changed: " + e.getMessage()));
+		} catch (InvocationTargetException e) {
+		    throw throwNewUnusableEntryException(
+			    new IncompatibleClassChangeError(realClass + " changed: " + e.getMessage()));
+		}
 
                 Field[] fields = getFields(realClass);
 


### PR DESCRIPTION
I was seeing a compile error after the fix for: replacement of Class::newInstance() is deprecated #97

I slapped a `final` on that variable so I wouldn't have to worry about reassignment, etc.

(Sorry for the import re-sort. Got tired of battling IDE. If offensive, I'll figure out how to undo that bit).