### PR TITLE
fix build error caused by server side changes on TravisCI re OracleJdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 script: mvn -f ./JGDMS/pom.xml test


### PR DESCRIPTION
The following build error was described as a result of changes to the Travis server side moving from Trusty to Xenial, where OracleJDK8 is not supported.

Trying openjdk8 instead. May also look into different CI system.

see: https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365 