### PR TITLE
Update bnd-maven-plugin to fix ConcurrentModificationException

### DIFF
--- a/JGDMS/pom.xml
+++ b/JGDMS/pom.xml
@@ -189,7 +189,7 @@
         <plugin>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>bnd-maven-plugin</artifactId>
-            <version>4.2.0</version>
+            <version>7.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
fix: biz.aQute.bnd:bnd-maven-plugin:4.2.0:bnd-process (default) on project jgdms-collections: bnd error: null: ConcurrentModificationException

```
[ERROR] Failed to execute goal biz.aQute.bnd:bnd-maven-plugin:4.2.0:bnd-process (default) on project jgdms-collections: bnd error: null: ConcurrentModificationException -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :jgdms-collections
```

Pretty sure other errors will follow, but this gets the build further along.